### PR TITLE
update to latest react-i18nify

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "git://github.com/zoover/react-redux-i18n.git"
   },
   "dependencies": {
-    "react-i18nify": "1.8.7"
+    "react-i18nify": "~1.8.8"
   },
   "devDependencies": {
     "babel-eslint": "^7.1.1",


### PR DESCRIPTION
Update to latest react-i18nify with ~1.8.8, so next time there is a minor release of react-i18nify, you won't need to do a new release of react-redux-i18n.
react-i18nify 1.8.8 contains this change https://github.com/JSxMachina/react-i18nify/pull/35